### PR TITLE
Better failure on non-json responses

### DIFF
--- a/tests/test_trading_client.py
+++ b/tests/test_trading_client.py
@@ -15,10 +15,17 @@ class TradingTests(unittest.TestCase):
         self.username = 'USERNAME'
         self.key = 'KEY'
         self.secret = 'SECRET'
-        self.client = bitstamp.client.Trading(self.username, self.key, self.secret)
+        self.client = bitstamp.client.Trading(
+            self.username, self.key, self.secret)
 
     def test_bad_response(self):
         response = FakeResponse(b'''{"error": "something went wrong"}''')
+        with mock.patch('requests.post', return_value=response):
+            self.assertRaises(
+                bitstamp.client.BitstampError, self.client.account_balance)
+
+    def test_nonjson_response(self):
+        response = FakeResponse(b'''Hey wait, this isn't JSON!''')
         with mock.patch('requests.post', return_value=response):
             self.assertRaises(
                 bitstamp.client.BitstampError, self.client.account_balance)
@@ -138,8 +145,8 @@ class TradingTests(unittest.TestCase):
         response = FakeResponse(b'''{"id": "1"}''')
         with mock.patch('requests.post', return_value=response):
             result = self.client.unconfirmed_bitcoin_deposits()
-        print(result)
         self.assertIsInstance(result, dict)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Bitstamp's API is playing up at the moment, and returning a short HTML response rather than JSON.

The generic JSON decoding failure exception isn't very useful, and it also highlighted a bug that for non-json responses it could still result in this exception getting raised.
